### PR TITLE
add FSDP implementation of aurora model training

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,5 @@ cd examples/
 torchrun --standalone --nnodes=1 --nproc-per-node=4 \
          train_ddp.py --nsamples 12 --samples-per-batch 4
 ```
+
+To run the training using FSDP on one or more nodes, please refer to [document](README_fsdp.md)

--- a/README_fsdp.md
+++ b/README_fsdp.md
@@ -1,0 +1,228 @@
+# Multi-Node FSDP Training for Aurora
+
+This guide explains how to run Fully Sharded Data Parallel (FSDP) training for the Aurora model across multiple nodes, each with multiple GPUs.
+
+## Prerequisites
+
+- Multiple compute nodes with CUDA-capable GPUs
+- Network connectivity between all nodes 
+- Same number of GPUs on each node
+- NCCL support for inter-node communication
+- PyTorch with distributed training support
+
+## Run Single-Node Training
+
+For single-node training with multiple GPUs, use the `run_fsdp_singlenode.sh` script:
+
+```bash
+./run_fsdp_singlenode.sh --num_gpus 4 --save_model
+```
+
+### Basic Usage
+
+```bash
+cd examples
+./run_fsdp_singlenode.sh [OPTIONS]
+```
+
+### Common Options
+
+- `--num_gpus`: Number of GPUs to use (default: 4)
+- `--nsamples`: Total number of samples to generate (default: 256)
+- `--samples-per-batch`: Samples per gpu per batch (default: 4)
+- `--nepochs`: Number of training epochs (default: 3)
+- `--save_model`: Enable model checkpoint saving
+- `--cpu_offload`: Offload parameters to CPU when not in use
+
+### Example
+
+```bash
+./run_fsdp_singlenode.sh \
+  --num_gpus 4 \
+  --nsamples 128 \
+  --samples-per-batch 8 \
+  --nepochs 3 \
+  --save_model \
+  --output_dir "./output/my_experiment"
+```
+
+
+## Running Multi-Node Training
+
+The multi-node training script (`run_fsdp_multinode.sh`) must be executed on each participating node with appropriate parameters.
+
+### Basic Usage
+
+You need to run the script on each node with these mandatory parameters:
+
+```bash
+# On node 0 (master node)
+./run_fsdp_multinode.sh --nnodes 2 --node_rank 0 --master_addr <MASTER_IP> --master_port 29500 --save_model
+
+# On node 1
+./run_fsdp_multinode.sh --nnodes 2 --node_rank 1 --master_addr <MASTER_IP> --master_port 29500 --save_model
+```
+
+### Required Parameters
+
+- `--nnodes`: Total number of nodes participating in training
+- `--node_rank`: Rank of the current node (0 to nnodes-1)
+- `--master_addr`: IP address of the master node (node with rank 0)  
+- `--master_port`: Available port on the master node for coordination
+
+### Common Training Configuration
+
+These parameters should be consistent across all nodes:
+
+```bash
+--num_gpus_per_node 4 \
+--nsamples 24 \
+--samples-per-batch 3 \
+--nepochs 10 \
+--nlat 180 \
+--nlon 360 \
+--sharding_strategy full_shard \
+--output_dir ./output \
+```
+
+## Example: 2-Node Training with 4 GPUs per Node
+
+Start training on the master node (192.168.1.100):
+
+```bash
+./run_fsdp_multinode.sh \
+  --nnodes 2 \
+  --node_rank 0 \
+  --master_addr 192.168.1.100 \
+  --master_port 29500 \
+  --num_gpus_per_node 4 \
+  --nsamples 24 \
+  --samples-per-batch 3 \
+  --nepochs 10 \
+  --use_mixed_precision \
+  --use_bfloat16 \
+  --save_model
+```
+
+Then, on the second node:
+
+```bash
+./run_fsdp_multinode.sh \
+  --nnodes 2 \
+  --node_rank 1 \
+  --master_addr 192.168.1.100 \
+  --master_port 29500 \
+  --num_gpus_per_node 4 \
+  --nsamples 24 \
+  --samples-per-batch 3 \
+  --nepochs 10 \
+  --use_mixed_precision \
+  --use_bfloat16 \
+  --save_model
+```
+
+## Using SLURM in HPC Environments
+
+If you're using SLURM, you can create a submission script like this:
+
+```bash
+#!/bin/bash
+#SBATCH --job-name=aurora_fsdp
+#SBATCH --nodes=2
+#SBATCH --ntasks-per-node=1
+#SBATCH --gpus-per-node=4
+#SBATCH --cpus-per-task=32
+#SBATCH --time=12:00:00
+
+# Get the node hostnames
+NODES=$(scontrol show hostnames $SLURM_JOB_NODELIST)
+NODES_ARRAY=($NODES)
+
+# Get the first node as the master node
+MASTER_NODE=${NODES_ARRAY[0]}
+MASTER_ADDR=$(srun --nodes=1 --ntasks=1 -w $MASTER_NODE hostname --ip-address)
+MASTER_PORT=29500
+
+# Run the distributed training
+srun ./run_fsdp_multinode.sh \
+  --nnodes=$SLURM_JOB_NUM_NODES \
+  --node_rank=$SLURM_NODEID \
+  --master_addr=$MASTER_ADDR \
+  --master_port=$MASTER_PORT \
+  --num_gpus_per_node=4 \
+  --nsamples 24 \
+  --samples-per-batch 6 \
+  --nepochs 10 \
+  --use_mixed_precision \
+  --use_bfloat16 \
+  --save_model
+```
+
+## Troubleshooting
+
+1. **NCCL errors**: Set `export NCCL_DEBUG=INFO` to get more diagnostic information
+2. **Network issues**: Ensure all nodes can communicate with each other
+3. **Different configurations**: Make sure all nodes use the same training parameters
+4. **PyTorch version mismatch**: Use the same PyTorch version across all nodes
+5. **GPU memory OOM**: Try reducing the batch size or use CPU offloading
+
+For more help, check the logs in the `logs/` directory on each node.
+
+### Known Issue - Mixed Precision Options NOT Fully Functioning Yet
+
+Aurora model requires special handling for mixed precision:
+- `--use_mixed_precision`: Enables mixed precision training
+- `--use_bfloat16`: BFloat16 is recommended for Aurora as it keeps critical buffers in FP32
+
+There is a longitude range issue with mixed precision when running the command `./run_fsdp_singlenode.sh --use_mixed_precision --use_bfloat16`:
+```
+[rank0]: Traceback (most recent call last):
+[rank0]:   File "/lustre/xuco/workspace/llm/aurora-training/examples/train_fsdp.py", line 453, in <module>
+[rank0]:     main(args)
+[rank0]:   File "/lustre/xuco/workspace/llm/aurora-training/examples/train_fsdp.py", line 260, in main
+[rank0]:     pred = model(batch_input).normalise(surf_stats)
+[rank0]:            ^^^^^^^^^^^^^^^^^^
+[rank0]:   File "/lustre/xuco/software/miniconda3/envs/aurora/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1739, in _wrapped_call_impl
+[rank0]:     return self._call_impl(*args, **kwargs)
+[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[rank0]:   File "/lustre/xuco/software/miniconda3/envs/aurora/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1750, in _call_impl
+[rank0]:     return forward_call(*args, **kwargs)
+[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[rank0]:   File "/lustre/xuco/software/miniconda3/envs/aurora/lib/python3.11/site-packages/torch/distributed/fsdp/fully_sharded_data_parallel.py", line 848, in forward
+[rank0]:     args, kwargs = _root_pre_forward(self, self, args, kwargs)
+[rank0]:                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[rank0]:   File "/lustre/xuco/software/miniconda3/envs/aurora/lib/python3.11/site-packages/torch/distributed/fsdp/_runtime_utils.py", line 596, in _root_pre_forward
+[rank0]:     return _root_cast_forward_input(state, module, args, kwargs)
+[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[rank0]:   File "/lustre/xuco/software/miniconda3/envs/aurora/lib/python3.11/site-packages/torch/distributed/fsdp/_runtime_utils.py", line 614, in _root_cast_forward_input
+[rank0]:     args, kwargs = _cast_forward_inputs(input_dtype, *args, **kwargs)
+[rank0]:                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[rank0]:   File "/lustre/xuco/software/miniconda3/envs/aurora/lib/python3.11/site-packages/torch/distributed/utils.py", line 74, in _cast_forward_inputs
+[rank0]:     return (_apply_to_tensors(cast_fn, args), _apply_to_tensors(cast_fn, kwargs))
+[rank0]:             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[rank0]:   File "/lustre/xuco/software/miniconda3/envs/aurora/lib/python3.11/site-packages/torch/distributed/utils.py", line 263, in _apply_to_tensors
+[rank0]:     return apply(container)
+[rank0]:            ^^^^^^^^^^^^^^^^
+[rank0]:   File "/lustre/xuco/software/miniconda3/envs/aurora/lib/python3.11/site-packages/torch/distributed/utils.py", line 259, in apply
+[rank0]:     return type(x)(apply(el) for el in x)
+[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[rank0]:   File "/lustre/xuco/software/miniconda3/envs/aurora/lib/python3.11/site-packages/torch/distributed/utils.py", line 259, in <genexpr>
+[rank0]:     return type(x)(apply(el) for el in x)
+[rank0]:                    ^^^^^^^^^
+[rank0]:   File "/lustre/xuco/software/miniconda3/envs/aurora/lib/python3.11/site-packages/torch/distributed/utils.py", line 241, in apply
+[rank0]:     changes = {
+[rank0]:               ^
+[rank0]:   File "/lustre/xuco/software/miniconda3/envs/aurora/lib/python3.11/site-packages/torch/distributed/utils.py", line 242, in <dictcomp>
+[rank0]:     f.name: apply(getattr(dc, f.name)) for f in dataclasses.fields(dc)
+[rank0]:             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+[rank0]:   File "/lustre/xuco/software/miniconda3/envs/aurora/lib/python3.11/site-packages/torch/distributed/utils.py", line 244, in apply
+[rank0]:     return dataclasses.replace(dc, **changes)
+[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[rank0]:   File "/lustre/xuco/software/miniconda3/envs/aurora/lib/python3.11/dataclasses.py", line 1503, in replace
+[rank0]:     return obj.__class__(**changes)
+[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^
+[rank0]:   File "<string>", line 8, in __init__
+[rank0]:   File "/lustre/xuco/software/miniconda3/envs/aurora/lib/python3.11/site-packages/aurora/batch.py", line 49, in __post_init__
+[rank0]:     raise ValueError("Longitudes must be in the range [0, 360).")
+[rank0]: ValueError: Longitudes must be in the range [0, 360).
+```

--- a/examples/run_fsdp_multinode.sh
+++ b/examples/run_fsdp_multinode.sh
@@ -1,0 +1,249 @@
+#!/bin/bash
+# Script to run FSDP training on multiple nodes, each with the same number of GPUs
+
+# Usage info
+usage() {
+  echo "Usage: $0 [OPTIONS]"
+  echo "Run FSDP training across multiple nodes"
+  echo
+  echo "Mandatory options:"
+  echo "  --nnodes NUM              Number of nodes for training (required)"
+  echo "  --node_rank RANK          Rank of this node (0 to nnodes-1) (required)"
+  echo "  --master_addr HOST        IP address of the master node (required)"
+  echo "  --master_port PORT        Port on the master node for coordination (required)"
+  echo
+  echo "Optional arguments:"
+  echo "  --num_gpus_per_node NUM   Number of GPUs per node (default: all available)"
+  echo "  --nsamples NUM            Number of samples for training (default: 12)"
+  echo "  --samples-per-batch NUM   Samples per batch (default: 3)"
+  echo "  --nepochs NUM             Number of training epochs (default: 10)"
+  echo "  --nlat NUM                Number of latitude points (default: 180)"
+  echo "  --nlon NUM                Number of longitude points (default: 360)"
+  echo "  --ntime_input NUM         Number of time inputs (default: 2)"
+  echo "  --optimizer NAME          Optimizer to use (default: Adam)"
+  echo "  --lr NUM                  Learning rate (default: 3e-4)"
+  echo "  --weight_decay NUM        Weight decay factor (default: 0.01)"
+  echo "  --max_grad_norm NUM       Max gradient norm for clipping (default: 1.0)"
+  echo "  --sharding_strategy STR   FSDP sharding strategy (default: full_shard)"
+  echo "  --output_dir PATH         Directory to save outputs (default: ./output)"
+  echo "  --use_lora                Enable LoRA for training"
+  echo "  --use_mixed_precision     Enable mixed precision training"
+  echo "  --cpu_offload             Enable CPU offloading"
+  echo "  --verbose                 Enable verbose logging"
+  echo "  --save_model              Enable model saving"
+  echo "  --help                    Display this help message and exit"
+  exit 1
+}
+
+# Check for help flag
+if [[ "$1" == "--help" || "$1" == "-h" ]]; then
+  usage
+fi
+
+# Required parameters check
+if [[ -z "$1" ]]; then
+  echo "Error: Required parameters missing"
+  usage
+fi
+
+# Set environment variables for distributed training
+export NCCL_DEBUG=INFO
+
+# Default parameters
+NUM_GPUS_PER_NODE=$(nvidia-smi --query-gpu=name --format=csv,noheader | wc -l)
+NSAMPLES=12
+SAMPLES_PER_BATCH=3
+NEPOCHS=10
+NLAT=180
+NLON=360
+NTIME_INPUT=2
+OPTIMIZER="Adam"
+SHARDING_STRATEGY="full_shard"
+LR=3e-4
+WEIGHT_DECAY=0.01
+MAX_GRAD_NORM=1.0
+OUTPUT_DIR="./output"
+
+# Required parameters (must be set by user)
+NNODES=""
+NODE_RANK=""
+MASTER_ADDR=""
+MASTER_PORT=""
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --nnodes)
+      NNODES="$2"
+      shift 2
+      ;;
+    --node_rank)
+      NODE_RANK="$2"
+      shift 2
+      ;;
+    --master_addr)
+      MASTER_ADDR="$2"
+      shift 2
+      ;;
+    --master_port)
+      MASTER_PORT="$2"
+      shift 2
+      ;;
+    --num_gpus_per_node)
+      NUM_GPUS_PER_NODE="$2"
+      shift 2
+      ;;
+    --nsamples)
+      NSAMPLES="$2"
+      shift 2
+      ;;
+    --samples-per-batch)
+      SAMPLES_PER_BATCH="$2"
+      shift 2
+      ;;
+    --nepochs)
+      NEPOCHS="$2"
+      shift 2
+      ;;
+    --nlat)
+      NLAT="$2"
+      shift 2
+      ;;
+    --nlon)
+      NLON="$2"
+      shift 2
+      ;;
+    --ntime_input)
+      NTIME_INPUT="$2"
+      shift 2
+      ;;
+    --optimizer)
+      OPTIMIZER="$2"
+      shift 2
+      ;;
+    --lr)
+      LR="$2"
+      shift 2
+      ;;
+    --weight_decay)
+      WEIGHT_DECAY="$2"
+      shift 2
+      ;;
+    --max_grad_norm)
+      MAX_GRAD_NORM="$2"
+      shift 2
+      ;;
+    --sharding_strategy)
+      SHARDING_STRATEGY="$2"
+      shift 2
+      ;;
+    --output_dir)
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    --use_lora)
+      USE_LORA="--use_lora"
+      shift
+      ;;
+    --use_mixed_precision)
+      USE_MIXED_PRECISION="--use_mixed_precision"
+      shift
+      ;;
+    --use_bfloat16)
+      USE_BFLOAT16="--use_bfloat16"
+      shift
+      ;;
+    --cpu_offload)
+      CPU_OFFLOAD="--cpu_offload"
+      shift
+      ;;
+    --verbose)
+      VERBOSE="--verbose"
+      shift
+      ;;
+    --save_model)
+      SAVE_MODEL="--save_model"
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1"
+      usage
+      ;;
+  esac
+done
+
+# Check if required parameters are provided
+if [[ -z "$NNODES" || -z "$NODE_RANK" || -z "$MASTER_ADDR" || -z "$MASTER_PORT" ]]; then
+  echo "Error: Required parameters missing"
+  echo "NNODES: $NNODES"
+  echo "NODE_RANK: $NODE_RANK"
+  echo "MASTER_ADDR: $MASTER_ADDR"
+  echo "MASTER_PORT: $MASTER_PORT"
+  usage
+fi
+
+# Create log directory
+mkdir -p logs
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+LOG_FILE="logs/fsdp_node${NODE_RANK}_${TIMESTAMP}.log"
+
+# Set distributed environment variables
+export MASTER_ADDR=$MASTER_ADDR
+export MASTER_PORT=$MASTER_PORT
+
+# Print configuration
+echo "=== Multi-Node FSDP Training Configuration ==="
+echo "Number of nodes: $NNODES"
+echo "This node rank: $NODE_RANK"
+echo "Master node address: $MASTER_ADDR"
+echo "Master node port: $MASTER_PORT"
+echo "Number of GPUs per node: $NUM_GPUS_PER_NODE"
+echo "Total GPUs: $((NNODES * NUM_GPUS_PER_NODE))"
+echo "Samples: $NSAMPLES"
+echo "Samples per batch: $SAMPLES_PER_BATCH"
+echo "Epochs: $NEPOCHS"
+echo "Grid: ${NLAT}x${NLON}"
+echo "Time inputs: $NTIME_INPUT"
+echo "Optimizer: $OPTIMIZER (lr=${LR}, weight_decay=${WEIGHT_DECAY})"
+echo "Max gradient norm: $MAX_GRAD_NORM"
+echo "Sharding strategy: $SHARDING_STRATEGY"
+echo "Output directory: $OUTPUT_DIR"
+echo "Mixed precision: ${USE_MIXED_PRECISION:+enabled}${USE_MIXED_PRECISION:+${USE_BFLOAT16:+ (bfloat16)}${USE_BFLOAT16:-' (float16)'}}"
+echo "CPU offload: ${CPU_OFFLOAD:+enabled}"
+echo "Use LoRA: ${USE_LORA:+enabled}"
+echo "Verbose logging: ${VERBOSE:+enabled}"
+echo "Save model: ${SAVE_MODEL:+enabled}"
+echo "Log file: $LOG_FILE"
+echo "=============================================="
+
+# Run the training script with torchrun
+echo "Starting multi-node FSDP training with $NUM_GPUS_PER_NODE GPUs on this node (rank $NODE_RANK), logs will be saved to $LOG_FILE"
+
+torchrun \
+  --nnodes=$NNODES \
+  --node_rank=$NODE_RANK \
+  --nproc_per_node=$NUM_GPUS_PER_NODE \
+  --master_addr=$MASTER_ADDR \
+  --master_port=$MASTER_PORT \
+  train_fsdp.py \
+  --nsamples $NSAMPLES \
+  --samples-per-batch $SAMPLES_PER_BATCH \
+  --nepochs $NEPOCHS \
+  --nlat $NLAT \
+  --nlon $NLON \
+  --ntime_input $NTIME_INPUT \
+  --optimizer $OPTIMIZER \
+  --lr $LR \
+  --weight_decay $WEIGHT_DECAY \
+  --max_grad_norm $MAX_GRAD_NORM \
+  --sharding_strategy $SHARDING_STRATEGY \
+  --output_dir $OUTPUT_DIR \
+  $USE_MIXED_PRECISION \
+  $USE_BFLOAT16 \
+  $CPU_OFFLOAD \
+  $USE_LORA \
+  $VERBOSE \
+  $SAVE_MODEL \
+  2>&1 | tee $LOG_FILE
+
+echo "Node $NODE_RANK: Training completed. Log saved to $LOG_FILE"

--- a/examples/run_fsdp_singlenode.sh
+++ b/examples/run_fsdp_singlenode.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+# Script to run the fixed FSDP training on A100 GPUs
+
+# Set environment variables
+# export NCCL_DEBUG=INFO
+
+# Default parameters
+NUM_GPUS=4
+NSAMPLES=256
+SAMPLES_PER_BATCH=4
+NEPOCHS=3
+NLAT=180
+NLON=360
+NTIME_INPUT=2
+OPTIMIZER="Adam"
+SHARDING_STRATEGY="full_shard"
+LR=3e-4
+WEIGHT_DECAY=0.01
+MAX_GRAD_NORM=1.0
+OUTPUT_DIR="./output"
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --num_gpus)
+      NUM_GPUS="$2"
+      shift 2
+      ;;
+    --nsamples)
+      NSAMPLES="$2"
+      shift 2
+      ;;
+    --samples-per-batch)
+      SAMPLES_PER_BATCH="$2"
+      shift 2
+      ;;
+    --nepochs)
+      NEPOCHS="$2"
+      shift 2
+      ;;
+    --nlat)
+      NLAT="$2"
+      shift 2
+      ;;
+    --nlon)
+      NLON="$2"
+      shift 2
+      ;;
+    --ntime_input)
+      NTIME_INPUT="$2"
+      shift 2
+      ;;
+    --optimizer)
+      OPTIMIZER="$2"
+      shift 2
+      ;;
+    --lr)
+      LR="$2"
+      shift 2
+      ;;
+    --weight_decay)
+      WEIGHT_DECAY="$2"
+      shift 2
+      ;;
+    --max_grad_norm)
+      MAX_GRAD_NORM="$2"
+      shift 2
+      ;;
+    --sharding_strategy)
+      SHARDING_STRATEGY="$2"
+      shift 2
+      ;;
+    --output_dir)
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    --use_lora)
+      USE_LORA="--use_lora"
+      shift
+      ;;
+    --use_mixed_precision)
+      USE_MIXED_PRECISION="--use_mixed_precision"
+      shift
+      ;;
+    --use_bfloat16)
+      USE_BFLOAT16="--use_bfloat16"
+      shift
+      ;;
+    --cpu_offload)
+      CPU_OFFLOAD="--cpu_offload"
+      shift
+      ;;
+    --verbose)
+      VERBOSE="--verbose"
+      shift
+      ;;
+    --save_model)
+      SAVE_MODEL="--save_model"
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+# Create log directory
+mkdir -p logs
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+LOG_FILE="logs/fsdp_run_${TIMESTAMP}.log"
+
+# Print configuration
+echo "=== FSDP Training Configuration ==="
+echo "Number of GPUs: $NUM_GPUS"
+echo "Samples: $NSAMPLES"
+echo "Samples per batch: $SAMPLES_PER_BATCH"
+echo "Epochs: $NEPOCHS"
+echo "Grid: ${NLAT}x${NLON}"
+echo "Time inputs: $NTIME_INPUT"
+echo "Optimizer: $OPTIMIZER (lr=${LR}, weight_decay=${WEIGHT_DECAY})"
+echo "Max gradient norm: $MAX_GRAD_NORM"
+echo "Sharding strategy: $SHARDING_STRATEGY"
+echo "Output directory: $OUTPUT_DIR"
+echo "Mixed precision: ${USE_MIXED_PRECISION:+enabled}${USE_MIXED_PRECISION:+${USE_BFLOAT16:+ (bfloat16)}${USE_BFLOAT16:-' (float16)'}}"
+echo "CPU offload: ${CPU_OFFLOAD:+enabled}"
+echo "Use LoRA: ${USE_LORA:+enabled}"
+echo "Verbose logging: ${VERBOSE:+enabled}"
+echo "Save model: ${SAVE_MODEL:+enabled}"
+echo "Log file: $LOG_FILE"
+echo "====================================="
+
+# Run the training script with torchrun
+echo "Starting FSDP training with $NUM_GPUS GPUs, logs will be saved to $LOG_FILE"
+
+torchrun --standalone --nnodes=1 --nproc_per_node=$NUM_GPUS \
+  train_fsdp.py \
+  --nsamples $NSAMPLES \
+  --samples-per-batch $SAMPLES_PER_BATCH \
+  --nepochs $NEPOCHS \
+  --nlat $NLAT \
+  --nlon $NLON \
+  --ntime_input $NTIME_INPUT \
+  --optimizer $OPTIMIZER \
+  --lr $LR \
+  --weight_decay $WEIGHT_DECAY \
+  --max_grad_norm $MAX_GRAD_NORM \
+  --sharding_strategy $SHARDING_STRATEGY \
+  --output_dir $OUTPUT_DIR \
+  $USE_MIXED_PRECISION \
+  $USE_BFLOAT16 \
+  $CPU_OFFLOAD \
+  $USE_LORA \
+  $VERBOSE \
+  $SAVE_MODEL \
+  2>&1 | tee $LOG_FILE
+
+echo "Training completed. Log saved to $LOG_FILE"

--- a/examples/train_fsdp.py
+++ b/examples/train_fsdp.py
@@ -1,0 +1,453 @@
+import argparse
+import os
+import time
+import functools
+from datetime import datetime
+
+import torch
+import torch.distributed as dist
+from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import apply_activation_checkpointing
+from torch.distributed.fsdp import (
+    FullyShardedDataParallel as FSDP,
+    MixedPrecision,
+    ShardingStrategy,
+    CPUOffload,
+    StateDictType,
+    BackwardPrefetch,
+    FullStateDictConfig,
+)
+from torch.distributed.fsdp.wrap import transformer_auto_wrap_policy
+from torch.utils.data import DataLoader, DistributedSampler
+
+from aurora import Aurora
+from aurora.model.swin3d import BasicLayer3D
+from aurora_training.training.defaults import w_s, w_c
+from aurora_training.training.loss import loss_function
+from aurora_training.utils.data import (
+    generate_batch,
+    calc_surf_stats,
+    collate_mappable_batch,
+    DatasetBatch,
+    MappableBatch,
+)
+
+
+def setup_distributed(backend="nccl"):
+    """Set up distributed training environment."""
+    # Initialize the distributed environment
+    if "SLURM_PROCID" in os.environ:
+        # Running on a SLURM cluster
+        rank = int(os.environ["SLURM_PROCID"])
+        world_size = int(os.environ["SLURM_NTASKS"])
+        local_rank = int(os.environ["SLURM_LOCALID"])
+        node_rank = rank // int(os.environ.get("SLURM_GPUS_ON_NODE", 8))
+    else:
+        # Fallback for manual setup with torchrun
+        rank = int(os.environ.get("RANK", 0))
+        world_size = int(os.environ.get("WORLD_SIZE", 1))
+        local_rank = int(os.environ.get("LOCAL_RANK", 0))
+        node_rank = rank // torch.cuda.device_count()
+
+    # Set the device for this process
+    device = torch.device(f"cuda:{local_rank}")
+    torch.cuda.set_device(device)
+    
+    # Initialize the process group if not already initialized
+    if not dist.is_initialized():
+        dist.init_process_group(backend=backend)
+    
+    return rank, world_size, local_rank, device
+
+
+def create_fsdp_model(model, device, args):
+    """Wrap model with FSDP."""
+    # Define mixed precision policy
+    mp_policy = None
+    if args.use_mixed_precision:
+        # Check if BFloat16 is supported (preferred for stability)
+        bf16_ready = (
+            torch.cuda.is_available() and 
+            torch.cuda.is_bf16_supported() and
+            torch.version.cuda and
+            hasattr(torch.cuda, "get_device_capability") and
+            torch.cuda.get_device_capability()[0] >= 8  # Ampere GPUs and above
+        )
+        
+        if bf16_ready and args.use_bfloat16:
+            # Use bfloat16 for better numerical stability
+            mp_policy = MixedPrecision(
+                param_dtype=torch.bfloat16,
+                reduce_dtype=torch.bfloat16,
+                # Keep buffers in fp32 for stable training
+                buffer_dtype=torch.float32,
+            )
+        else:
+            # Use safer mixed precision that keeps critical buffers in fp32
+            mp_policy = MixedPrecision(
+                param_dtype=torch.float16,
+                reduce_dtype=torch.float16,
+                # Keep buffers in fp32 for stable training
+                buffer_dtype=torch.float32,
+            )
+    
+    # Configure CPU offloading
+    cpu_offload = None
+    if args.cpu_offload:
+        cpu_offload = CPUOffload(offload_params=True)
+    
+    # Configure FSDP auto wrap policy for Aurora's BasicLayer3D blocks
+    auto_wrap_policy = functools.partial(
+        transformer_auto_wrap_policy,
+        transformer_layer_cls={
+            BasicLayer3D,
+        },
+    )
+    
+    # Set sharding strategy
+    sharding_strategy = ShardingStrategy.FULL_SHARD
+    if args.sharding_strategy == "shard_grad_op":
+        sharding_strategy = ShardingStrategy.SHARD_GRAD_OP
+    elif args.sharding_strategy == "no_shard":
+        sharding_strategy = ShardingStrategy.NO_SHARD
+    
+    # Create FSDP model with all configurations at once
+    fsdp_model = FSDP(
+        model.to(device),
+        auto_wrap_policy=auto_wrap_policy,
+        sharding_strategy=sharding_strategy,
+        device_id=device,
+        mixed_precision=mp_policy if mp_policy else None,
+        cpu_offload=cpu_offload if cpu_offload else None,
+        backward_prefetch=BackwardPrefetch.BACKWARD_PRE  # Enable backward prefetch for better performance
+    )
+    
+    # Configure activation checkpointing
+    apply_activation_checkpointing(fsdp_model, check_fn=lambda x: isinstance(x, BasicLayer3D))
+    
+    return fsdp_model
+
+
+def save_checkpoint(model, optimizer, epoch, loss, args, rank):
+    """Save model checkpoint."""
+    # Create directory on rank 0 only
+    if rank == 0:
+        checkpoint_dir = os.path.join(args.output_dir, "checkpoints")
+        os.makedirs(checkpoint_dir, exist_ok=True)
+    
+    # Make sure all processes reach this point before continuing
+    torch.distributed.barrier()
+    
+    # For FSDP, use streaming to CPU to save state dict
+    save_policy = FullStateDictConfig(offload_to_cpu=True, rank0_only=True)
+    
+    # All processes need to participate in the state_dict_type context
+    with FSDP.state_dict_type(model, StateDictType.FULL_STATE_DICT, save_policy):
+        # Only rank 0 actually creates the dictionary and saves
+        if rank == 0:
+            cpu_state = {
+                'epoch': epoch,
+                'model': model.state_dict(),
+                'optimizer': optimizer.state_dict(),
+                'loss': loss,
+                'args': args,
+            }
+            
+            checkpoint_path = os.path.join(checkpoint_dir, f"checkpoint_epoch_{epoch}.pt")
+            torch.save(cpu_state, checkpoint_path)
+            print(f"Saved checkpoint to {checkpoint_path}")
+        else:
+            # Non-rank 0 processes still need to call state_dict to participate in 
+            # the collective operation, but we discard the result
+            _ = model.state_dict()
+            _ = optimizer.state_dict()
+    
+    # Ensure all processes are synchronized after saving
+    torch.distributed.barrier()
+    
+    # Clean up any cached memory
+    torch.cuda.empty_cache()
+
+
+def main(args):
+    # Setup distributed environment
+    rank, world_size, local_rank, device = setup_distributed()
+    
+    # Log distributed training info
+    if rank == 0:
+        print(f"Starting FSDP training with {world_size} processes")
+        print(f"World size: {world_size}, Rank: {rank}, Local rank: {local_rank}")
+        print(f"Sharding strategy: {args.sharding_strategy}")
+    
+    # Create output directory
+    if rank == 0 and args.save_model:
+        os.makedirs(args.output_dir, exist_ok=True)
+    
+    # Data parameters
+    NSAMPLES = args.nsamples
+    NEPOCHS = args.nepochs
+    NTIME_INPUT = args.ntime_input
+    NLAT = args.nlat
+    NLON = args.nlon
+    SAMPLES_PER_BATCH = int(args.samples_per_batch)
+    
+    # Generate data on rank 0 and distribute to all ranks
+    if rank == 0:
+        input = generate_batch(NSAMPLES, NTIME_INPUT, NLAT, NLON)
+        truth = generate_batch(NSAMPLES, 1, NLAT, NLON)  # Output always has len(time)=1
+        surf_stats = calc_surf_stats(input)
+        input = MappableBatch.from_batch(input.unnormalise(surf_stats))
+        truth = MappableBatch.from_batch(truth.unnormalise(surf_stats))
+        training_dataset = DatasetBatch(input, truth)
+        package = [training_dataset, surf_stats]
+    else:
+        package = [None, None]
+
+    dist.broadcast_object_list(package, src=0)
+
+    if rank != 0:
+        training_dataset = package[0]
+        surf_stats = package[1]
+
+    # Setup data loading
+    sampler = DistributedSampler(training_dataset)
+    dataloader = DataLoader(
+        training_dataset,
+        batch_size=SAMPLES_PER_BATCH,
+        shuffle=False,
+        sampler=sampler,
+        collate_fn=collate_mappable_batch,
+    )
+    
+    # Initialize model
+    model = Aurora(use_lora=args.use_lora, autocast=True, surf_stats=surf_stats)
+    model.train()
+    model.configure_activation_checkpointing()
+    
+    # Wrap model with FSDP
+    model = create_fsdp_model(model, device, args)
+    
+    # Create optimizer
+    optimizer = getattr(torch.optim, args.optimizer)(
+        model.parameters(), 
+        lr=args.lr, 
+        weight_decay=args.weight_decay
+    )
+    
+    # Training loop
+    start_time = time.time()
+    best_loss = float('inf')
+    best_loss_tensor = torch.tensor([best_loss], device=device)
+    
+    for epoch in range(NEPOCHS):
+        epoch_start = time.time()
+        sampler.set_epoch(epoch)
+        
+        if rank == 0:
+            print(f"Epoch {epoch+1}/{NEPOCHS}")
+        
+        # Training loop
+        model.train()
+        total_loss = 0.0
+        num_batches = 0
+        
+        for batch_input, batch_truth in dataloader:
+            # Move data to device
+            batch_input = batch_input.to(device)
+            batch_truth = batch_truth.to(device)
+            
+            # Forward pass
+            optimizer.zero_grad()
+            pred = model(batch_input).normalise(surf_stats)
+            
+            # Calculate loss
+            loss = loss_function(
+                pred, batch_truth.normalise(surf_stats), w_s, w_c
+            )
+            
+            # Backward pass
+            loss.backward()
+            
+            # Apply gradient clipping
+            if args.max_grad_norm > 0:
+                torch.nn.utils.clip_grad_norm_(model.parameters(), args.max_grad_norm)
+            
+            # Update weights
+            optimizer.step()
+            
+            # Accumulate loss
+            total_loss += loss.item()
+            num_batches += 1
+            
+            # Log batch progress
+            if args.verbose and rank == 0 and num_batches % args.log_interval == 0:
+                print(f"  Batch {num_batches}, Loss: {loss.item():.4f}")
+        
+        # Calculate average loss for the epoch
+        avg_loss = total_loss / num_batches if num_batches > 0 else float('inf')
+        
+        # Gather loss from all processes for correct reporting
+        loss_tensor = torch.tensor([avg_loss], device=device)
+        dist.all_reduce(loss_tensor, op=dist.ReduceOp.SUM)
+        avg_loss = loss_tensor.item() / world_size
+        
+        # Log epoch results
+        epoch_time = time.time() - epoch_start
+        if rank == 0:
+            print(f"  Epoch {epoch+1} completed in {epoch_time:.2f}s | Avg Loss: {avg_loss:.4f}")
+        
+        # Save checkpoint if requested
+        if args.save_model and (epoch + 1) % args.save_interval == 0:
+            save_checkpoint(model, optimizer, epoch + 1, avg_loss, args, rank)
+            
+        # Save best model - synchronize the best_loss across all processes
+        is_best = avg_loss < best_loss
+        if args.save_model and is_best:
+            # Update best loss
+            best_loss = avg_loss
+            best_loss_tensor[0] = best_loss
+            
+            # Broadcast best loss from rank 0 to ensure all processes have the same value
+            dist.broadcast(best_loss_tensor, src=0)
+            best_loss = best_loss_tensor.item()
+            
+            # Save best checkpoint
+            save_checkpoint(model, optimizer, epoch + 1, avg_loss, args, rank)
+    
+    # Log final training stats
+    if rank == 0:
+        total_time = time.time() - start_time
+        print(f"{NEPOCHS} epochs completed in {total_time:.2f}s")
+    
+    # Save final checkpoint
+    if args.save_model:
+        save_checkpoint(model, optimizer, NEPOCHS, avg_loss, args, rank)
+    
+    # Clean up
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Train Aurora model with FSDP")
+    # Data parameters
+    parser.add_argument(
+        "--nsamples",
+        help="The total number of samples to generate for training",
+        default=12,
+        type=int,
+    )
+    parser.add_argument(
+        "--nepochs", 
+        help="The number of epochs to train for", 
+        default=5, 
+        type=int,
+    )
+    parser.add_argument(
+        "--ntime_input", 
+        help="The number of time levels in the input", 
+        default=2,
+        type=int,
+    )
+    parser.add_argument(
+        "--nlat", 
+        help="Number of zonal points", 
+        default=180,
+        type=int,
+    )
+    parser.add_argument(
+        "--nlon", 
+        help="Number of meridional points", 
+        default=360,
+        type=int,
+    )
+    
+    # Training parameters
+    parser.add_argument(
+        "--optimizer", 
+        help="The name of the optimizer to use", 
+        default="Adam",
+    )
+    parser.add_argument(
+        "--lr",
+        help="Learning rate",
+        default=3e-4,
+        type=float,
+    )
+    parser.add_argument(
+        "--weight_decay",
+        help="Weight decay",
+        default=0.01,
+        type=float,
+    )
+    parser.add_argument(
+        "--samples-per-batch", 
+        help="Number of samples to draw per batch", 
+        default=1,
+        type=int,
+    )
+    parser.add_argument(
+        "--use_lora", 
+        help="Use LoRA for parameter-efficient training", 
+        action="store_true",
+    )
+    parser.add_argument(
+        "--max_grad_norm",
+        help="Maximum gradient norm for clipping",
+        default=1.0,
+        type=float,
+    )
+    
+    # FSDP parameters
+    parser.add_argument(
+        "--sharding_strategy",
+        help="FSDP sharding strategy",
+        choices=["full_shard", "shard_grad_op", "no_shard"],
+        default="full_shard",
+    )
+    parser.add_argument(
+        "--use_mixed_precision",
+        help="Use mixed precision for training",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--use_bfloat16",
+        help="Use bfloat16 precision (requires Ampere or newer GPUs)",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--cpu_offload",
+        help="Offload parameters to CPU when not in use",
+        action="store_true",
+    )
+    
+    # Logging and saving parameters
+    parser.add_argument(
+        "--verbose", 
+        help="Print verbose training information", 
+        action="store_true",
+    )
+    parser.add_argument(
+        "--save_model", 
+        help="Save model checkpoint after training", 
+        action="store_true",
+    )
+    parser.add_argument(
+        "--output_dir", 
+        help="Directory to save checkpoints", 
+        default="./output",
+        type=str,
+    )
+    parser.add_argument(
+        "--log_interval", 
+        help="Logging interval in batches", 
+        default=10,
+        type=int,
+    )
+    parser.add_argument(
+        "--save_interval", 
+        help="Checkpoint saving interval in epochs", 
+        default=1,
+        type=int,
+    )
+    
+    args = parser.parse_args()
+    main(args)

--- a/grid_batch_size_contraints.md
+++ b/grid_batch_size_contraints.md
@@ -1,0 +1,48 @@
+# Grid & Batch Size Constraints in High-Resolution Training
+
+## Problem Description
+When increasing the spatial resolution from 180×360 to 720×1440 (NLAT & NLON ×4) on a node with 4 A100 GPUs, training the Aurora model under FSDP triggers a CUDA error:
+
+```
+RuntimeError: CUDA error: invalid configuration argument
+```
+
+This error originates in PyTorch’s `scaled_dot_product_attention` kernel during level aggregation in the Perceiver encoder.
+
+## Root Cause Analysis
+- **Token Explosion**: With a 4×4 patch, each sample produces `(720/4)×(1440/4)=64 800` tokens per pressure level.
+- **Flattening & Batch Dim**: In `Perceiver3DEncoder.aggregate_levels`, tokens of shape `(B, C_A, L, D)` are flattened to `(B×L, C_A, D)` before attention.
+- **Head Count**: Scaled-dot-product launches one CUDA block per (batch×head×query) combination. With 16 heads and B×L ≈ 64 800, blocks ≈ 1 036 800.
+- **CUDA Grid Limit**: On A100 (and most GPUs), `gridDim.x` max is 65 535. Launching >65 535 blocks in x dimension triggers “invalid configuration argument.”
+
+---
+
+## Debug & Validation Steps
+1. Print `B` and `L` just before flatten in `aggregate_levels` to confirm sizes.
+2. Run with `CUDA_LAUNCH_BLOCKING=1` to pinpoint the failing launch.
+3. Compile with `TORCH_USE_CUDA_DSA=1` for device-side assertions.
+
+## Mitigation Strategies
+
+1. **Reduce Batch Size**
+   - Decrease `--samples-per-batch` to ensure that `B×L×num_heads` remains within 65,535.
+   - During my tests, I had to set `--samples-per-batch` to `1` to achieve this.
+2. **Chunk Level Aggregation**
+   In `aggregate_levels`, split the token dimension `L` into smaller slices:
+   ```python
+   max_q = 4096  # ensure max_q × num_heads ≤ 65535
+   out_chunks = []
+   for i in range(0, L, max_q):
+       xs = x[:, :, i:i+max_q, :]
+       ls = latents[:, :, i:i+max_q, :]
+       flat_xs = xs.flatten(0, 1)      # (B2×Q, C_A, D)
+       flat_ls = ls.flatten(0, 1)
+       flat_out = self.level_agg(flat_ls, flat_xs)
+       out = flat_out.unflatten(0, (B2, -1)).permute(0, 2, 1, 3)
+       out_chunks.append(out)
+   return torch.cat(out_chunks, dim=2)
+   ```
+3. **Reduce Token Count**
+   - Increase patch size (e.g. from 4 to 8) or lower grid resolution.
+
+**Result**: Applying one of these strategies might help keep CUDA grid launches within hardware limits and restore training at full resolution.


### PR DESCRIPTION
**Description:**

This PR introduces end-to-end FSDP support for the Aurora model, including:

- **Training driver**  
  - `train_fsdp.py` wraps Aurora in FSDP and supports mixed precision, CPU offloading, activation checkpointing, and periodic checkpoint saving  
- **Documentation**  
  - Added `README_fsdp.md` covering single- and multi-node usage, SLURM examples, common options, and troubleshooting  
  - `grid_batch_size_constraints.md` diagnoses CUDA grid-launch limits at high resolution and outlines mitigation strategies  
- **Launch scripts**  
  - `run_fsdp_singlenode.sh` for one-node FSDP  
  - `run_fsdp_multinode.sh` for multi-node FSDP  


### Testing

I first set `NLAT=720` and `NLON=1440` in `run_fsdp_singlenode.sh`. With the following script (where the batch size per GPU is 1 and CPU offload is enabled), I was able to train the model on a single node with 4 A100s, which was a bit surprising to me.

  ```bash
  ./run_fsdp_singlenode.sh \
    --num_gpus 4 \
    --nsamples 16 \
    --samples-per-batch 1 \
    --nepochs 3 \
    --cpu_offload
  ```
- **Multi-node (2 nodes, 8× A100s)**  
  Run `run_fsdp_multinode.sh` on each node with `--nnodes=2`, appropriate `--node_rank`, and `--master_addr/port`.


### Known issue

Using BFloat16 mixed precision at high resolutions can trigger a longitude-range error in data preprocessing; a fix will follow.